### PR TITLE
feat(blur): implement blur according to `WlRegion`s

### DIFF
--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -80,6 +80,7 @@ use crate::render_helpers::solid_color::{SolidColorBuffer, SolidColorRenderEleme
 use crate::render_helpers::texture::TextureBuffer;
 use crate::render_helpers::{BakedBuffer, RenderTarget, SplitElements};
 use crate::rubber_band::RubberBand;
+use crate::utils::region::Region;
 use crate::utils::transaction::{Transaction, TransactionBlocker};
 use crate::utils::{
     ResizeEdge, ensure_min_max_size_maybe_zero, output_matches_name, output_size,
@@ -296,6 +297,10 @@ pub trait LayoutElement {
 
     fn wants_blur(&self) -> bool {
         false
+    }
+
+    fn blur_preferred_region(&self) -> Option<Region<i32, Logical>> {
+        None
     }
 }
 

--- a/src/protocols/ext_background_effect.rs
+++ b/src/protocols/ext_background_effect.rs
@@ -4,7 +4,8 @@ use smithay::reexports::{
         ext_background_effect_surface_v1::{self, ExtBackgroundEffectSurfaceV1},
     },
     wayland_server::{
-        Client, Dispatch, DisplayHandle, GlobalDispatch, protocol::wl_surface::WlSurface,
+        Client, Dispatch, DisplayHandle, GlobalDispatch,
+        protocol::{wl_region::WlRegion, wl_surface::WlSurface},
     },
 };
 
@@ -39,6 +40,7 @@ pub trait ExtBackgroundEffectManagerHandler {
     fn ext_background_effect_manager_state(&mut self) -> &mut ExtBackgroundEffectManagerState;
     fn enable_blur(&mut self, surface: &WlSurface);
     fn disable_blur(&mut self, surface: &WlSurface);
+    fn set_blur_region(&mut self, surface: &WlSurface, region: Option<WlRegion>);
 }
 
 pub struct ExtBackgroundEffectManagerGlobalData {
@@ -119,9 +121,11 @@ where
                 state.disable_blur(&data.surface);
             }
             ext_background_effect_surface_v1::Request::SetBlurRegion { region } => {
-                // We currently only have "all or nothing" blur, meaning if the region is not
-                // `NULL`, we enable it, otherwise we disable it.
-                if region.is_some() {
+                let should_blur = region.is_some();
+
+                state.set_blur_region(&data.surface, region);
+
+                if should_blur {
                     state.enable_blur(&data.surface);
                 } else {
                     state.disable_blur(&data.surface);

--- a/src/protocols/kde_blur.rs
+++ b/src/protocols/kde_blur.rs
@@ -1,6 +1,6 @@
 use smithay::reexports::wayland_server::{
     Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
-    protocol::wl_surface::WlSurface,
+    protocol::{wl_region::WlRegion, wl_surface::WlSurface},
 };
 use wayland_protocols_plasma::blur::server::{
     org_kde_kwin_blur::OrgKdeKwinBlur, org_kde_kwin_blur_manager::OrgKdeKwinBlurManager,
@@ -41,6 +41,7 @@ pub trait OrgKdeKwinBlurManagerHandler {
     fn org_kde_kwin_blur_manager_state(&mut self) -> &mut OrgKdeKwinBlurManagerState;
     fn enable_blur(&mut self, surface: &WlSurface);
     fn disable_blur(&mut self, surface: &WlSurface);
+    fn set_blur_region(&mut self, surface: &WlSurface, region: Option<WlRegion>);
 }
 
 impl<D> GlobalDispatch<OrgKdeKwinBlurManager, OrgKdeKwinBlurManagerGlobalData, D>
@@ -119,9 +120,9 @@ where
                 state.enable_blur(&data.surface);
             }
             wayland_protocols_plasma::blur::server::org_kde_kwin_blur::Request::SetRegion {
-                region: _,
+                region,
             } => {
-                // setting blur on a specific WlRegion is not yet supported
+                state.set_blur_region(&data.surface, region);
             }
             wayland_protocols_plasma::blur::server::org_kde_kwin_blur::Request::Release => {}
             e => {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -34,6 +34,7 @@ use crate::handlers::KdeDecorationsModeState;
 use crate::niri::ClientState;
 
 pub mod id;
+pub mod region;
 pub mod scale;
 pub mod signals;
 pub mod spawning;

--- a/src/utils/region.rs
+++ b/src/utils/region.rs
@@ -1,0 +1,104 @@
+use std::ops::{Add, AddAssign, Sub};
+
+use smithay::{
+    utils::{Coordinate, Logical, Point, Rectangle},
+    wayland::compositor::{RectangleKind, RegionAttributes},
+};
+
+/// A region described using a list of additive [`Rectangle`]s.
+#[derive(Debug, Clone)]
+pub struct Region<N, Kind>
+where
+    N: Coordinate + Default + PartialOrd + Add + Sub + Copy + AddAssign,
+{
+    rects: Vec<Rectangle<N, Kind>>,
+}
+
+impl<N, Kind> Region<N, Kind>
+where
+    N: Coordinate + Default + PartialOrd + Add + Sub + Copy + AddAssign,
+{
+    pub fn new() -> Self {
+        Self { rects: Vec::new() }
+    }
+
+    pub fn with_offset(&self, point: Point<N, Kind>) -> Self {
+        Self {
+            rects: self
+                .rects
+                .iter()
+                .copied()
+                .map(|mut r| {
+                    r.loc.x += point.x;
+                    r.loc.y += point.y;
+                    r
+                })
+                .collect(),
+        }
+    }
+
+    pub fn rects(&self) -> &[Rectangle<N, Kind>] {
+        &self.rects
+    }
+
+    pub fn subtract_rect(&mut self, rect: Rectangle<N, Kind>) {
+        self.rects =
+            Rectangle::subtract_rects_many(self.rects.iter().copied(), std::iter::once(rect));
+    }
+
+    pub fn add_rect(&mut self, rect: Rectangle<N, Kind>) {
+        if !self.rects.iter().any(|r| r.intersection(rect).is_some()) {
+            // nothing intersects, so we can just add this rectangle as-is
+            self.rects.push(rect);
+        } else if self.rects.iter().any(|r| r.contains_rect(rect)) {
+            // we are not adding any new rects
+        } else {
+            // something intersects, so we only add the new portions to our list
+            self.rects
+                .append(&mut rect.subtract_rects(self.rects.clone()));
+        }
+    }
+
+    pub fn from_rects(rects: impl IntoIterator<Item = Rectangle<N, Kind>>) -> Self {
+        Self {
+            rects: rects.into_iter().collect(),
+        }
+    }
+}
+
+impl Region<i32, Logical> {
+    pub fn from_region_attributes(value: RegionAttributes) -> Self {
+        let len = value.rects.len();
+
+        value.rects.into_iter().fold(
+            Self {
+                rects: Vec::with_capacity(len),
+            },
+            |mut acc, (kind, rect)| {
+                match kind {
+                    RectangleKind::Add => acc.add_rect(rect),
+                    RectangleKind::Subtract => acc.subtract_rect(rect),
+                }
+                acc
+            },
+        )
+    }
+}
+
+impl From<RegionAttributes> for Region<i32, Logical> {
+    fn from(value: RegionAttributes) -> Self {
+        Self::from_region_attributes(value)
+    }
+}
+
+impl<N, Kind> FromIterator<Rectangle<N, Kind>> for Region<N, Kind>
+where
+    N: Coordinate + Default + PartialOrd + Add + Sub + Copy + AddAssign,
+{
+    fn from_iter<T: IntoIterator<Item = Rectangle<N, Kind>>>(iter: T) -> Self {
+        iter.into_iter().fold(Self::new(), |mut acc, curr| {
+            acc.add_rect(curr);
+            acc
+        })
+    }
+}


### PR DESCRIPTION
Closes #27 

Adds the implementation for blurring specific `WlRegion`s for layer surfaces. With this change, plasmashell was able to successfully blur its own panels.