### PR TITLE
feat: use kde portal file picker dialog

### DIFF
--- a/nix/modules/niri-nixos.nix
+++ b/nix/modules/niri-nixos.nix
@@ -3,6 +3,7 @@
 }:
 {
   pkgs,
+  lib,
   ...
 }:
 {
@@ -10,5 +11,17 @@
     overlay
   ];
 
-  programs.niri.package = pkgs.niriPackages.niri;
+  programs.niri = {
+    package = pkgs.niriPackages.niri;
+    useNautilus = false;
+  };
+
+  xdg.portal = {
+    extraPortals = [
+      pkgs.kdePackages.xdg-desktop-portal-kde
+    ];
+    config.niri = {
+      "org.freedesktop.impl.portal.FileChooser" = lib.mkForce "kde";
+    };
+  };
 }


### PR DESCRIPTION
Love the idea for the project!

Never understood why is everyone using gnome/gtk stuff, given how gnome project treats community.
I'm hoping with the rise of quickshell something will change in that regard

Given that the end goal of this project is more kde and less gnome, my first proposal is to replace awful gnome file picker which was obviously not made for human consumption:
<img width="1118" height="717" alt="image" src="https://github.com/user-attachments/assets/38468108-7d91-41b7-9e38-2187ffbd1f09" />

With superior KDE one:
<img width="1693" height="954" alt="image" src="https://github.com/user-attachments/assets/660c66e2-982d-416e-b9fb-61b9c26b3e69" />

I'm also thinking about writing a complete portal replacement, which should also help with things such as screencasts, but for now it seems to be quite complex, so one step at a time.
It is also possible to replace more things with kde portal already, but there are some missing wayland protocols which I'm trying to implement right now.